### PR TITLE
Add virtual ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+## v0.2.0-beta
+
 - Fixed bug where /loaded_preset_dump_from_midi_input_port and /saved_preset_dump_from_midi_input_port_to_preset OSC messages were not being sent with the MIDI port name
+- Added virtual MIDI ports on macOS so that DAWs can directly communicate via MIDI with nymphes-osc
+- Added separate feedback suppression time for SYSEX messages, as they appear to sometimes be echoed back after a very long delay (many seconds) 
+
 
 ## v0.1.9-beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed bug where /loaded_preset_dump_from_midi_input_port and /saved_preset_dump_from_midi_input_port_to_preset OSC messages were not being sent with the MIDI port name
+
 ## v0.1.9-beta
 
 - Added MIDI feedback suppression, to prevent feedback from connected MIDI outputs and inputs


### PR DESCRIPTION
- Fixed bug where /loaded_preset_dump_from_midi_input_port and /saved_preset_dump_from_midi_input_port_to_preset OSC messages were not being sent with the MIDI port name
- Added virtual MIDI ports on macOS so that DAWs can directly communicate via MIDI with nymphes-osc
- Added separate feedback suppression time for SYSEX messages, as they appear to sometimes be echoed back after a very long delay (many seconds) 
