### PR TITLE
Improve logging when messages with an unexpected MIDI Channel arrive from nymphes

### DIFF
--- a/src/nymphes_midi/NymphesMIDI.py
+++ b/src/nymphes_midi/NymphesMIDI.py
@@ -1567,8 +1567,10 @@ class NymphesMIDI:
             if not self._ignore_control_change_messages_from_nymphes:
                 # Make sure the message was received on the Nymphes MIDI Channel
                 if msg.channel != self._nymphes_midi_channel - 1:
-                    self.logger.warning(f'Received a MIDI Control Change message from Nymphes on a different channel: {msg}')
-
+                    self.logger.warning(f'Received a MIDI Control Change message from Nymphes on a different channel. ' 
+                                        f'Expected channel={self._nymphes_midi_channel}. ' 
+                                        f'Actual channel={msg.channel + 1}. ' 
+                                        f'Message: {msg}.')
                 else:
                     if msg.control == 0:
                         #


### PR DESCRIPTION
Change the warning logs from:
```
WARNING - Received a MIDI Control Change message from Nymphes on a different channel: control_change channel=1 control=74 value=127 time=0
```
to
```
WARNING - Received a control_change message from Nymphes on a different channel. Expected channel=1. Actual channel=2. Message: control_change channel=1 control=79 value=1 time=1744881216.2275019.
```