### PR TITLE
Added new feature: /connect_first_detected_nymphes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 - Message logging improved when a MIDI CC is received from Nymphes on an unexpected channel.
 - Fixed bug in NymphesOSC _get_local_ip_address which could cause a crash
 - Added utilities module to nymphes_osc
+- Added ability to connect to the first detected Nymphes and set it as the default
+- Added /connect_first_detected_nymphes OSC message
 
 
 ## v1.0.1

--- a/README.md
+++ b/README.md
@@ -303,6 +303,9 @@ You can also use `nymphes-osc --help` to see a help message listing the argument
     - Type: String
     - Description: The name of the MIDI Output port for Nymphes (as reported by mido.get_output_names())
 
+#### /connect_first_detected_nymphes
+- Description: Connect to the first Nymphes connected to the computer
+
 #### /disconnect_nymphes
 - Description: Disconnect from Nymphes MIDI ports
 - Arguments: None

--- a/src/nymphes_midi/NymphesMIDI.py
+++ b/src/nymphes_midi/NymphesMIDI.py
@@ -25,8 +25,13 @@ class NymphesMIDI:
             self,
             notification_callback_function,
             log_level=logging.WARNING,
-            presets_directory_path=None
+            presets_directory_path=None,
+            should_connect_first_detected_nymphes=True
     ):
+        # If this is True then connect to the first detected Nymphes, when it
+        # is detected
+        self.waiting_to_connect_first_detected_nymphes = should_connect_first_detected_nymphes
+
         # Callback function for us to call with notifications.
         self._notification_callback_function = notification_callback_function
 
@@ -612,6 +617,17 @@ class NymphesMIDI:
                 if curr_time > msg.time:
                     self._midi_feedback_suppression_messages_list.remove(msg)
 
+        if self.waiting_to_connect_first_detected_nymphes:
+            input_port_name = self._detected_nymphes_midi_inputs[0]
+            output_port_name = self._detected_nymphes_midi_outputs[0]
+            if input_port_name is not None and output_port_name is not None:
+                self.logger.info("About to connect to first detected Nymphes...")
+                self.connect_nymphes(
+                    input_port_name=input_port_name,
+                    output_port_name=output_port_name
+                )
+                self.waiting_to_connect_first_detected_nymphes = False
+
     def connect_nymphes(self, input_port_name, output_port_name):
         """
         Connect the specified MIDI input and output ports
@@ -677,6 +693,20 @@ class NymphesMIDI:
         else:
             if was_connected:
                 self._on_nymphes_disconnected()
+
+    def connect_first_detected_nymphes(self):
+        """
+        Connect to the first detected Nymphes
+        :return:
+        """
+        input_port_name = self._detected_nymphes_midi_inputs[0]
+        output_port_name = self._detected_nymphes_midi_outputs[0]
+        if input_port_name is not None and output_port_name is not None:
+            self.logger.info("About to connect to first detected Nymphes...")
+            self.connect_nymphes(
+                input_port_name=input_port_name,
+                output_port_name=output_port_name
+            )
 
     def disconnect_nymphes(self):
         """

--- a/src/nymphes_osc/NymphesOSC.py
+++ b/src/nymphes_osc/NymphesOSC.py
@@ -91,7 +91,8 @@ class NymphesOSC:
             mdns_name=None,
             osc_log_level=logging.DEBUG,
             midi_log_level=logging.DEBUG,
-            presets_directory_path=None
+            presets_directory_path=None,
+            should_connect_first_detected_nymphes=True
     ):
 
         # Get logger
@@ -113,7 +114,8 @@ class NymphesOSC:
         self._nymphes_midi = NymphesMIDI(
             notification_callback_function=self._on_nymphes_notification,
             log_level=midi_log_level,
-            presets_directory_path=presets_directory_path
+            presets_directory_path=presets_directory_path,
+            should_connect_first_detected_nymphes=should_connect_first_detected_nymphes
         )
 
         # The MIDI channel Nymphes is set to use.
@@ -222,6 +224,11 @@ class NymphesOSC:
         self._dispatcher.map(
             '/connect_nymphes',
             self._on_osc_message_connect_nymphes,
+            needs_reply_address=True
+        )
+        self._dispatcher.map(
+            '/connect_first_detected_nymphes',
+            self._on_osc_message_connect_first_detected_nymphes,
             needs_reply_address=True
         )
         self._dispatcher.map(
@@ -940,6 +947,26 @@ class NymphesOSC:
                 input_port_name=input_port_name,
                 output_port_name=output_port_name
             )
+
+        except Exception as e:
+            # Send status update and log it
+            status = f'Failed to connect Nymphes'
+            self._send_error_message_to_osc_clients(status, str(e))
+            self.logger.warning(f'{status}: {e}')
+
+    def _on_osc_message_connect_first_detected_nymphes(self, sender_ip, address, *args):
+        """
+        Connect to the first Nymphes connected to the computer.
+        :param sender_ip: This is the automatically-detected IP address of the sender
+        :param address: (str) The OSC address of the message
+        :param *args: The OSC message's arguments
+        :return:
+        """
+        try:
+            self.logger.info(f'Received {address} from {sender_ip[0]}')
+
+            # Connect to the MIDI ports
+            self._nymphes_midi.connect_first_detected_nymphes()
 
         except Exception as e:
             # Send status update and log it


### PR DESCRIPTION
This is also set as the default, so Nymphes is automatically connected the first time it is detected, without the client needing to send the commande to connect to Nymphes.